### PR TITLE
yaml.SafeLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ hashed_passwords = stauth.Hasher(['123', '456']).generate()
 
 ```python
 with open('../config.yaml') as file:
-    config = yaml.load(file, Loader=SafeLoader)
+    config = yaml.load(file, Loader=yaml.SafeLoader)
 
 authenticator = stauth.Authenticate(
     config['credentials'],


### PR DESCRIPTION
It may be confusing for the user to determine where to import SafeLoader, as .load is called with yaml.load. To avoid confusion, it would be better to use yaml.SafeLoader.