### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ hashed_passwords = stauth.Hasher(['abc', 'def']).generate()
 * Subsequently import the configuration file into your script and create an authentication object.
 
 ```python
+import yaml 
 from yaml.loader import SafeLoader
 
 with open('../config.yaml') as file:


### PR DESCRIPTION
Unless You do `import yaml`, One will get this error `NameError: name 'yaml' is not defined`. This is very very important.