### PR TITLE
Add optional key= parm to logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ name, authentication_status, username = authenticator.login('Login', 'main')
 
 ### 3. Authenticating users
 
-* You can then use the returned name and authentication status to allow your verified user to proceed to any restricted content. In addition, you have the ability to add an optional logout button at any location on your main body or sidebar (will default to main body).
+* You can then use the returned name and authentication status to allow your verified user to proceed to any restricted content. In addition, you have the ability to add an optional logout button at any location on your main body or sidebar (will default to main body).  The optional `key=` parameter to `authenticator.logout()` is provided for multipage streamlit apps that place logout buttons on multiple pages, as streamlit may complaining about duplicate keys.
 
 ```python
 if authentication_status:
-    authenticator.logout('Logout', 'main')
+    authenticator.logout('Logout', 'main', key='my_unique_key')
     st.write(f'Welcome *{name}*')
     st.title('Some content')
 elif authentication_status is False:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Streamlit-Authenticator [![Downloads](https://pepy.tech/badge/streamlit-authenticator)](https://pepy.tech/project/streamlit-authenticator) 
+# Streamlit-Authenticator [![Downloads](https://pepy.tech/badge/streamlit-authenticator)](https://pepy.tech/project/streamlit-authenticator)
 <!--- [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/khorasani) --->
 **A secure authentication module to validate user credentials in a Streamlit application.**
 
-<a href="https://amzn.to/3eQwEEn"><img src="https://raw.githubusercontent.com/mkhorasani/streamlit_authenticator_test/main/Web%20App%20Web%20Dev%20with%20Streamlit%20-%20Cover.png" width="300" height="450"> 
- 
+<a href="https://amzn.to/3eQwEEn"><img src="https://raw.githubusercontent.com/mkhorasani/streamlit_authenticator_test/main/Web%20App%20Web%20Dev%20with%20Streamlit%20-%20Cover.png" width="300" height="450">
+
 ###### _To learn more please refer to my book [Web Application Development with Streamlit](https://amzn.to/3eQwEEn)._
 
-  
+
 ## Installation
 
 Streamlit-Authenticator is distributed via [PyPI](https://pypi.org/project/streamlit-authenticator/):
@@ -85,11 +85,11 @@ name, authentication_status, username = authenticator.login('Login', 'main')
 
 ### 3. Authenticating users
 
-* You can then use the returned name and authentication status to allow your verified user to proceed to any restricted content. In addition, you have the ability to add an optional logout button at any location on your main body or sidebar (will default to main body).  The optional `key=` parameter to `authenticator.logout()` is provided for multipage streamlit apps that place logout buttons on multiple pages, as streamlit may complaining about duplicate keys.
+* You can then use the returned name and authentication status to allow your verified user to proceed to any restricted content. In addition, you have the ability to add an optional logout button at any location on your main body or sidebar (will default to main body). The optional **key** parameter for the logout widget should be used with multipage applications to prevent Streamlit from throwing duplicate key errors.
 
 ```python
 if authentication_status:
-    authenticator.logout('Logout', 'main', key='my_unique_key')
+    authenticator.logout('Logout', 'main', key='unique_key')
     st.write(f'Welcome *{name}*')
     st.title('Some content')
 elif authentication_status is False:

--- a/streamlit_authenticator/authenticate.py
+++ b/streamlit_authenticator/authenticate.py
@@ -193,7 +193,7 @@ class Authenticate:
 
         return st.session_state['name'], st.session_state['authentication_status'], st.session_state['username']
 
-    def logout(self, button_name: str, location: str='main'):
+    def logout(self, button_name: str, location: str='main', key: str=None):
         """
         Creates a logout button.
 
@@ -214,7 +214,7 @@ class Authenticate:
                 st.session_state['username'] = None
                 st.session_state['authentication_status'] = None
         elif location == 'sidebar':
-            if st.sidebar.button(button_name):
+            if st.sidebar.button(button_name, key):
                 self.cookie_manager.delete(self.cookie_name)
                 st.session_state['logout'] = True
                 st.session_state['name'] = None

--- a/streamlit_authenticator/authenticate.py
+++ b/streamlit_authenticator/authenticate.py
@@ -207,7 +207,7 @@ class Authenticate:
         if location not in ['main', 'sidebar']:
             raise ValueError("Location must be one of 'main' or 'sidebar'")
         if location == 'main':
-            if st.button(button_name):
+            if st.button(button_name, key):
                 self.cookie_manager.delete(self.cookie_name)
                 st.session_state['logout'] = True
                 st.session_state['name'] = None


### PR DESCRIPTION
If the app has several pages, and you put a logout button on each page, streamlit generates duplicate keys and complains about it.

Added optional key= parameter so the app can generate unique keys for streamlit.