### PR TITLE
Update authentication_controller.py

### DIFF
--- a/streamlit_authenticator/controllers/authentication_controller.py
+++ b/streamlit_authenticator/controllers/authentication_controller.py
@@ -46,7 +46,7 @@ class AuthenticationController:
                                                         pre_authorized,
                                                         validator,
                                                         auto_hash)
-        self.validator = Validator()
+        self.validator = validator if validator is not None else Validator()
     def _check_captcha(self, captcha_name: str, exception: Exception, entered_captcha: str):
         """
         Checks the validity of the entered captcha.


### PR DESCRIPTION
Browser generated passwords aren't accepted by the default password validation. I saw could provide my own validation class but it wasn't used. Found out this line was the culprit. Now custom validation can be used. 