### PR TITLE
Enhanced compatibility for Microsoft Guest Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ if st.session_state['authentication_status']:
 try:
     email_of_registered_user, \
     username_of_registered_user, \
-    name_of_registered_user = authenticator.register_user(pre_authorized=config['pre-authorized'])
+    name_of_registered_user = authenticator.register_user(pre_authorized=config['pre-authorized']['emails'])
     if email_of_registered_user:
         st.success('User registered successfully')
 except Exception as e:

--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ except LoginError as e:
 ![](https://github.com/mkhorasani/Streamlit-Authenticator/blob/main/graphics/guest_login_microsoft.JPG)
 
 * Please note that upon successful login, the guest user's name, email, and other information will be registered in the credentials dictionary and their re-authentication cookie will be saved automatically.
-* **_Please remember to update the config file (as shown in step 13) after you use this button._**
 
 ### 7. Authenticating users
 
@@ -487,7 +486,7 @@ if st.session_state['authentication_status']:
 
 ### 13. Updating the config file
 
-* Please ensure that the config file is re-saved anytime the credentials are updated or whenever the **experimental_guest_login**, **reset_password**, **register_user**, **forgot_password**, or **update_user_details** widgets are used.
+* Please ensure that the config file is re-saved anytime the credentials are updated or whenever the **reset_password**, **register_user**, **forgot_password**, or **update_user_details** widgets are used.
 
 ```python
 with open('../config.yaml', 'w') as file:

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ except LoginError as e:
 ![](https://github.com/mkhorasani/Streamlit-Authenticator/blob/main/graphics/guest_login_microsoft.JPG)
 
 * Please note that upon successful login, the guest user's name, email, and other information will be registered in the credentials dictionary and their re-authentication cookie will be saved automatically.
-* **_Please remember to update the config file (as shown in step 13) after you use this widget._**
+* **_Please remember to update the config file (as shown in step 13) after you use this button._**
 
 ### 7. Authenticating users
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ except LoginError as e:
 ![](https://github.com/mkhorasani/Streamlit-Authenticator/blob/main/graphics/guest_login_microsoft.JPG)
 
 * Please note that upon successful login, the guest user's name, email, and other information will be registered in the credentials dictionary and their re-authentication cookie will be saved automatically.
+* **_Please remember to update the config file (as shown in step 13) after you use this widget._**
 
 ### 7. Authenticating users
 
@@ -482,7 +483,7 @@ if st.session_state['authentication_status']:
 
 ### 13. Updating the config file
 
-* Please ensure that the config file is re-saved anytime the credentials are updated or whenever the **reset_password**, **register_user**, **forgot_password**, or **update_user_details** widgets are used.
+* Please ensure that the config file is re-saved anytime the credentials are updated or whenever the **experimental_guest_login**, **reset_password**, **register_user**, **forgot_password**, or **update_user_details** widgets are used.
 
 ```python
 with open('../config.yaml', 'w') as file:

--- a/streamlit_authenticator/models/authentication_model.py
+++ b/streamlit_authenticator/models/authentication_model.py
@@ -289,6 +289,8 @@ class AuthenticationModel:
                 max_concurrent_users - 1:
                 st.query_params.clear()
                 raise LoginError('Maximum number of concurrent users exceeded')
+            result['email'] = result.get('email', result.get('mail'))
+            result['family_name'] = result.get('family_name', result.get('surname'))
             if result['email'] not in self.credentials['usernames']:
                 self.credentials['usernames'][result['email']] = {}
             if not self._is_guest_user(result['email']):

--- a/streamlit_authenticator/models/authentication_model.py
+++ b/streamlit_authenticator/models/authentication_model.py
@@ -289,8 +289,7 @@ class AuthenticationModel:
                 max_concurrent_users - 1:
                 st.query_params.clear()
                 raise LoginError('Maximum number of concurrent users exceeded')
-            result['email'] = result.get('email', result.get('mail'))
-            result['family_name'] = result.get('family_name', result.get('surname'))
+            result['email'] = result.get('email', result.get('upn')).lower()
             if result['email'] not in self.credentials['usernames']:
                 self.credentials['usernames'][result['email']] = {}
             if not self._is_guest_user(result['email']):

--- a/streamlit_authenticator/models/oauth2/microsoft_model.py
+++ b/streamlit_authenticator/models/oauth2/microsoft_model.py
@@ -137,7 +137,7 @@ class MicrosoftModel:
                 print('No access token received')
                 st.rerun()
             token_json = self.decode_jwt(token_json['access_token'])
-            keys = {'email', 'family_name', 'given_name'}
+            keys = {'email', 'upn', 'family_name', 'given_name'}
             return {key: token_json[key] for key in keys if key in token_json}
             # user_info_url = "https://graph.microsoft.com/v1.0/me"
             # user_info_headers = {


### PR DESCRIPTION
1. Edited the get_microsoft_user_info() return value to include the Microsoft Entra UPN (User Principal Name), which is essentiallyan alternative name for the Email key
2. Coalesced the email and upn keys via `result['email'] = result.get('email', result.get('upn'))`
3. Forced the email / upn / username to lowercase in order to remove a bug where case differences between config.yaml and the returned email resulted in failed authentication