### PR TITLE
bugfix: using logout after experimental_login with google errors out.

### DIFF
--- a/streamlit_authenticator/models/authentication_model.py
+++ b/streamlit_authenticator/models/authentication_model.py
@@ -418,7 +418,8 @@ class AuthenticationModel:
         callback: callable, optional
             Callback function that will be invoked on button press.
         """
-        self.credentials['usernames'][st.session_state['username']]['logged_in'] = False
+        if st.session_state.get('username') in self.credentials['usernames']:
+            self.credentials['usernames'][st.session_state['username']]['logged_in'] = False
         st.session_state['logout'] = True
         st.session_state['name'] = None
         st.session_state['username'] = None


### PR DESCRIPTION
Using logout after experimental_login with google errors out

Was unable to logout without manually clearing cookies.  I think what happens is the __main__ runs through the logout once, clearing the username from the credentials, and then runs through it again, but the key no longer exists, so it errors out.

Fix simply adds an if check to make sure the `st.session_state['username']` exists

![Screenshot 2024-12-18 at 6 49 08 PM](https://github.com/user-attachments/assets/9117f956-5383-4b94-9ba5-f3585d7bfd34)

