### PR TITLE
Allow single-character names in validate_name

### DIFF
--- a/streamlit_authenticator/utilities/validator.py
+++ b/streamlit_authenticator/utilities/validator.py
@@ -93,7 +93,7 @@ class Validator:
         bool
             True if the name is valid, False otherwise.
         """
-        pattern = r"^[A-Za-z\u00C0-\u024F\u0370-\u1FFF\u2C00-\uD7FF\u4E00-\u9FFF' .-]{2,100}$"
+        pattern = r"^[A-Za-z\u00C0-\u024F\u0370-\u1FFF\u2C00-\uD7FF\u4E00-\u9FFF' .-]{1,100}$"
         return bool(re.match(pattern, name, re.UNICODE))
     def validate_password(self, password: str) -> bool:
         """


### PR DESCRIPTION
### Summary
This PR updates the `validate_name` regex to allow single-character names (`{1,100}` instead of `{2,100}`).

### Motivation
Currently, names must be at least 2 characters long.  
However, in many languages and cultures (especially East Asian ones), valid given names or family names can be only one character (e.g. 王, 李, 玲, 昇).  
Not allowing single-character names can prevent real users from registering properly.

### Change
- Modified `validate_name` regex:
  - from `{2,100}` → `{1,100}`

### Impact
- Improves inclusivity for users with valid one-character names.
- Backward compatible: maximum length (100) and allowed characters remain unchanged.

### Notes
This aligns with the project's past efforts (see PR #63) to support a wider variety of valid names worldwide.
