### PR TITLE
Fix invalid **kwargs type annotation in Authenticate constructor

### DIFF
--- a/streamlit_authenticator/views/authentication_view.py
+++ b/streamlit_authenticator/views/authentication_view.py
@@ -41,7 +41,7 @@ class Authenticate:
             validator: Optional[Validator] = None,
             auto_hash: bool = True,
             api_key: Optional[str] = None,
-            **kwargs: Optional[Dict[str, Any]]
+            **kwargs: Any
             ) -> None:
         """
         Initializes an instance of Authenticate.


### PR DESCRIPTION
## Summary

`Authenticate.__init__` annotates `**kwargs` as `Optional[Dict[str, Any]]`. That's not a valid way to type `**kwargs` — the annotation on a `**kwargs` parameter describes the type of each individual value passed in, not the aggregated dict. The correct annotation here is `Any`.

## Change

```python
-            **kwargs: Optional[Dict[str, Any]]
+            **kwargs: Any
```

Verified with mypy that this actually removes several spurious downstream errors in the same file (e.g. at the `time.sleep(...)` call sites) that were caused by `kwargs` being mistyped, with no new errors introduced.

Closes #287